### PR TITLE
docs: fix simple typo, requsted -> requested

### DIFF
--- a/src/bp.c
+++ b/src/bp.c
@@ -1861,7 +1861,7 @@ pb_step_lift(void)
 	if (d_t >= PB_CONN_LIFT_DURATION + STATE_TRANS_DELAY) {
 		if (late_plan_requested) {
 			/*
-			 * The user requsted a late plan, so this is as
+			 * The user requested a late plan, so this is as
 			 * far as we can go without segments. Also wait
 			 * for the camera to stop.
 			 */


### PR DESCRIPTION
There is a small typo in src/bp.c.

Should read `requested` rather than `requsted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md