### PR TITLE
Use XPLMGetScreenBoundsGlobal instead of XPLMGetScreenSize for button coordinates

### DIFF
--- a/src/bp.c
+++ b/src/bp.c
@@ -2218,11 +2218,14 @@ pb_step_closing_cradle(void)
 static void
 disco_win_draw(XPLMWindowID inWindowID, void *inRefcon)
 {
-	int w, h, mx, my;
+	int w, h, mx, my, left, top, right, bottom;
 
 	UNUSED(inRefcon);
-	XPLMGetScreenSize(&w, &h);
-	XPLMGetMouseLocation(&mx, &my);
+	XPLMGetScreenBoundsGlobal(&left, &top, &right, &bottom);
+	XPLMGetMouseLocationGlobal(&mx, &my);
+
+	w = right;
+	h = top;
 
 	XPLMSetGraphicsState(0, 1, 0, 0, 1, 0, 0);
 	if (inWindowID == bp_ls.disco_win) {
@@ -2337,9 +2340,12 @@ disco_intf_show(void)
 	    .handleMouseWheelFunc = nil_win_wheel,
 	    .refcon = NULL
 	};
-	int w, h;
+	int w, h, left, top, right, bottom;
 
-	XPLMGetScreenSize(&w, &h);
+	XPLMGetScreenBoundsGlobal(&left, &top, &right, &bottom);
+
+	w = right;
+	h = top;
 
 	disco_ops.left = w / 2 - 1.5 * disco_buttons[0].w;
 	disco_ops.right = w / 2 - 0.5 * disco_buttons[0].w;

--- a/src/bp_cam.c
+++ b/src/bp_cam.c
@@ -362,12 +362,15 @@ get_vp(vec4 vp)
 	vp[2] = vp_xp[2] - vp_xp[0];
 	vp[3] = vp_xp[3] - vp_xp[1];
 	if (vp[2] == 0 || vp[3] == 0) {
-		int scr_w, scr_h;
+		int scr_w, scr_h, left, top, right, bottom;
 		/*
 		 * Due to an outstanding X-Plane 11.50 beta bug, the viewport
 		 * dataref might not be properly updated in OpenGL mode.
 		 */
-		XPLMGetScreenSize(&scr_w, &scr_h);
+		XPLMGetScreenBoundsGlobal(&left, &top, &right, &bottom);
+		scr_w = right;
+		scr_h = top;
+
 		vp[2] = scr_w;
 		vp[3] = scr_h;
 	}
@@ -794,11 +797,14 @@ static void
 fake_win_draw(XPLMWindowID inWindowID, void *inRefcon)
 {
 	double scale;
-	int w, h, h_buttons, h_off;
+	int w, h, h_buttons, h_off, left, top, right, bottom;
 	UNUSED(inWindowID);
 	UNUSED(inRefcon);
 
-	XPLMGetScreenSize(&w, &h);
+	XPLMGetScreenBoundsGlobal(&left, &top, &right, &bottom);
+	w = right;
+	h = top;
+
 	XPLMSetWindowGeometry(fake_win, 0, h, w, 0);
 
 	if (!XPLMIsWindowInFront(fake_win))
@@ -835,9 +841,11 @@ static int
 button_hit_check(int x, int y)
 {
 	double scale;
-	int w, h, h_buttons, h_off;
+	int w, h, h_buttons, h_off, left, top, right, bottom;
 
-	XPLMGetScreenSize(&w, &h);
+	XPLMGetScreenBoundsGlobal(&left, &top, &right, &bottom);
+	w = right;
+	h = top;
 
 	h_buttons = 0;
 	for (int i = 0; buttons[i].filename != NULL; i++)
@@ -1139,7 +1147,10 @@ bp_cam_start(void)
 	}
 #endif	/* !PB_DEBUG_INTF */
 
-	XPLMGetScreenSize(&fake_win_ops.right, &fake_win_ops.top);
+	int left, top, right, bottom;
+	XPLMGetScreenBoundsGlobal(&left, &top, &right, &bottom);
+	fake_win_ops.right = right;
+	fake_win_ops.top = top;
 
 	circle_view_cmd = XPLMFindCommand("sim/view/circle");
 	ASSERT(circle_view_cmd != NULL);


### PR DESCRIPTION
When X-Plane User Interface scaling is set to 150% or 200%, BetterPushback doesn't show the _Disconnect Tow + Headset and switch to hand signals_ buttons or any buttons in the pushback planner window.

Using XPLMGetScreenBoundsGlobal instead of XPLMGetScreenSize for button coordinates fixes this behaviour for any UI scaling.

But I'm unable to test the changes on a multi-display setup.